### PR TITLE
Update progress bar width when terminal width changes.

### DIFF
--- a/lib/progress_bar.rb
+++ b/lib/progress_bar.rb
@@ -120,7 +120,13 @@ class ProgressBar
   end
 
   def terminal_width
-    @hl.output_cols.to_i
+    # HighLine check takes a long time, so only update width every second.
+    if @last_width_adjustment.nil? || Time.now - @last_width_adjustment > 1
+      @last_width_adjustment = Time.now
+      @terminal_width = @hl.output_cols.to_i
+    else
+      @terminal_width
+    end
   end
 
   def bar_width


### PR DESCRIPTION
I use a tiling window manager, so my term width changes a lot.

If you don't want to do it this way for performance reasons or whatnot, perhaps it could be made an option?

This reverts commit 2ae59f8aaf20df5b0f60050487d1c93ecac8e43b.
