### PR TITLE
Update README for specs and development dependencies

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -1,4 +1,3 @@
-
 # ProgressBar
 
 *ProgressBar* is a simple Ruby library for displaying progress of
@@ -72,9 +71,10 @@ pass them to the constructor:
 
 Run the tests to see examples of all the formats, with different values
 and maximums.
-
-    `rspec test/*_test.rb`
-
+```
+gem install --development progress_bar
+rspec spec/*_spec.rb
+```
 
 
 


### PR DESCRIPTION
I didn't see a test directory, so I figured the rspec line should be pointing at the spec directory. The `gem install --dev` line might be useful for folks who want to run the tests but don't know about development dependencies.
