### PR TITLE
Fixes undefined method error when using progress_bar in Rails 4.

### DIFF
--- a/lib/progress_bar.rb
+++ b/lib/progress_bar.rb
@@ -15,8 +15,8 @@ class ProgressBar
     @max        = args.shift if args.first.is_a? Numeric
     @meters     = args unless args.empty?
 
-    @last_write = Time.at(0)
-    @start      = Time.now
+    @last_write = ::Time.at(0)
+    @start      = ::Time.now
 
     @hl         = HighLine.new
   end


### PR DESCRIPTION
Not sure why, but after upgrading to Rails 4 this issue started. Now it explicitly loads the Time class form the default module to fix this issue, figured this change wouldn't hurt anyway.

```
undefined method `at' for ProgressBar::Time:Class
progress_bar-1.0.0/lib/progress_bar.rb:18:in `initialize'
```
