### PR TITLE
Use latest Ruby 2.1.x and newer Rubinius

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ script: rake spec
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.1
+  - 2.1.2
   - ruby-head
   - jruby-19mode
   - jruby-head
-  - rbx-2.1.1
+  - rbx-2
 


### PR DESCRIPTION
Rubinius has changed how they specify versions and the latest release is
actually 2.2.7. This change will ensure we run against the latest 2.x.y
version of Rubinius.
