### PR TITLE
Convert specs to RSpec 3.1.4 syntax with Transpec

### DIFF
--- a/spec/arguments_spec.rb
+++ b/spec/arguments_spec.rb
@@ -8,32 +8,32 @@ describe 'ProgressBar arguments' do
 
   it "should set appropriate defaults without any arguments" do
     bar = ProgressBar.new
-    bar.max.should == @default_max
-    bar.meters.should == @default_meters
+    expect(bar.max).to eq(@default_max)
+    expect(bar.meters).to eq(@default_meters)
   end
 
   it "should allow a single argument specifying the max" do
     bar = ProgressBar.new(123)
-    bar.max.should == 123
-    bar.meters.should == @default_meters
+    expect(bar.max).to eq(123)
+    expect(bar.meters).to eq(@default_meters)
   end
 
   it "should allow specifying just the meters" do
     bar = ProgressBar.new(:bar, :eta)
-    bar.max.should == @default_max
-    bar.meters.should == [:bar, :eta]
+    expect(bar.max).to eq(@default_max)
+    expect(bar.meters).to eq([:bar, :eta])
   end
 
   it "should allow specyfing the max and meters" do
     bar = ProgressBar.new(123, :bar, :eta)
-    bar.max.should == 123
-    bar.meters.should == [:bar, :eta]
+    expect(bar.max).to eq(123)
+    expect(bar.meters).to eq([:bar, :eta])
   end
 
   it "should raise an error when initial max is nonsense" do
-    lambda {
+    expect {
       bar = ProgressBar.new(0)
-    }.should raise_error(ProgressBar::ArgumentError)
+    }.to raise_error(ProgressBar::ArgumentError)
   end
 
 end

--- a/spec/bar_spec.rb
+++ b/spec/bar_spec.rb
@@ -3,7 +3,7 @@ require File.expand_path(File.join(File.dirname(__FILE__), 'spec_helper'))
 describe 'ProgressBar bar output' do
   before do
     @progress_bar = ProgressBar.new(100, :bar)
-    @progress_bar.stub(:terminal_width) { 12 }
+    allow(@progress_bar).to receive(:terminal_width) { 12 }
   end
 
   subject { @progress_bar.to_s }
@@ -13,7 +13,7 @@ describe 'ProgressBar bar output' do
       @progress_bar.count = 0
     end
 
-    it { should == "[          ]" }
+    it { is_expected.to eq("[          ]") }
   end
 
   describe 'at count=50' do
@@ -21,7 +21,7 @@ describe 'ProgressBar bar output' do
       @progress_bar.count = 50
     end
 
-    it { should == "[#####     ]" }
+    it { is_expected.to eq("[#####     ]") }
   end
 
   describe 'at count=100' do
@@ -29,7 +29,7 @@ describe 'ProgressBar bar output' do
       @progress_bar.count = 100
     end
 
-    it { should == "[##########]" }
+    it { is_expected.to eq("[##########]") }
   end
 
   describe 'at count=25 (non-integer divide, should round up)' do
@@ -37,7 +37,7 @@ describe 'ProgressBar bar output' do
       @progress_bar.count = 25
     end
 
-    it { should == "[###       ]" }
+    it { is_expected.to eq("[###       ]") }
   end
 
 end

--- a/spec/counter_spec.rb
+++ b/spec/counter_spec.rb
@@ -12,7 +12,7 @@ describe 'ProgressBar counter output' do
       @progress_bar.count = 0
     end
 
-    it { should == "[  0/100]" }
+    it { is_expected.to eq("[  0/100]") }
   end
 
   describe 'at count=50' do
@@ -20,7 +20,7 @@ describe 'ProgressBar counter output' do
       @progress_bar.count = 50
     end
 
-    it { should == "[ 50/100]" }
+    it { is_expected.to eq("[ 50/100]") }
   end
 
   describe 'at count=100' do
@@ -28,7 +28,7 @@ describe 'ProgressBar counter output' do
       @progress_bar.count = 100
     end
 
-    it { should == "[100/100]" }
+    it { is_expected.to eq("[100/100]") }
   end
 
   describe 'with a shorter max' do
@@ -36,7 +36,7 @@ describe 'ProgressBar counter output' do
       @progress_bar = ProgressBar.new(42, :counter)
     end
 
-    it { should == '[ 0/42]' }
+    it { is_expected.to eq('[ 0/42]') }
   end
 
   describe 'with a longer max' do
@@ -44,7 +44,7 @@ describe 'ProgressBar counter output' do
       @progress_bar = ProgressBar.new(4242, :counter)
     end
 
-    it { should == '[   0/4242]' }
+    it { is_expected.to eq('[   0/4242]') }
   end
 
 end

--- a/spec/elapsed_spec.rb
+++ b/spec/elapsed_spec.rb
@@ -15,7 +15,7 @@ describe 'ProgressBar elapsed output' do
       @progress_bar.count = 0
     end
 
-    it { should == "[00:10]" }
+    it { is_expected.to eq("[00:10]") }
   end
 
   describe 'at count=50' do
@@ -23,7 +23,7 @@ describe 'ProgressBar elapsed output' do
       @progress_bar.count = 50
     end
 
-    it { should == "[00:10]" }
+    it { is_expected.to eq("[00:10]") }
   end
 
   describe 'at count=100' do
@@ -31,7 +31,7 @@ describe 'ProgressBar elapsed output' do
       @progress_bar.count = 100
     end
 
-    it { should == "[00:10]" }
+    it { is_expected.to eq("[00:10]") }
   end
 
   describe 'with times over 1 hour' do
@@ -41,7 +41,7 @@ describe 'ProgressBar elapsed output' do
       Timecop.freeze Time.utc(2010, 3, 10, 2, 0, 0) # 2 hours later
     end
 
-    it { should == '[02:00:00]' }
+    it { is_expected.to eq('[02:00:00]') }
   end
 
 end

--- a/spec/eta_spec.rb
+++ b/spec/eta_spec.rb
@@ -14,7 +14,7 @@ describe 'ProgressBar eta output' do
       @progress_bar.count = 0
     end
 
-    it { should == "[00:00]" }
+    it { is_expected.to eq("[00:00]") }
   end
 
   describe 'at count=50' do
@@ -22,7 +22,7 @@ describe 'ProgressBar eta output' do
       @progress_bar.count = 50
     end
 
-    it { should == "[00:10]" }
+    it { is_expected.to eq("[00:10]") }
   end
 
   describe 'at count=100' do
@@ -30,7 +30,7 @@ describe 'ProgressBar eta output' do
       @progress_bar.count = 100
     end
 
-    it { should == "[00:00]" }
+    it { is_expected.to eq("[00:00]") }
   end
 
   describe 'with times over 1 hour' do
@@ -41,7 +41,7 @@ describe 'ProgressBar eta output' do
       Timecop.freeze Time.utc(2010, 3, 10, 2, 0, 0) # 2 hours later
     end
 
-    it { should == '[02:00:00]' }
+    it { is_expected.to eq('[02:00:00]') }
   end
 
 end

--- a/spec/percentage_spec.rb
+++ b/spec/percentage_spec.rb
@@ -12,7 +12,7 @@ describe 'ProgressBar percentage output' do
       @progress_bar.count = 0
     end
 
-    it { should == "[  0%]" }
+    it { is_expected.to eq("[  0%]") }
   end
 
   describe 'at count=50' do
@@ -20,7 +20,7 @@ describe 'ProgressBar percentage output' do
       @progress_bar.count = 50
     end
 
-    it { should == "[ 50%]" }
+    it { is_expected.to eq("[ 50%]") }
   end
 
   describe 'at count=100' do
@@ -28,7 +28,7 @@ describe 'ProgressBar percentage output' do
       @progress_bar.count = 100
     end
 
-    it { should == "[100%]" }
+    it { is_expected.to eq("[100%]") }
   end
 
   describe 'with a max that is not 100' do
@@ -37,7 +37,7 @@ describe 'ProgressBar percentage output' do
       @progress_bar.count = 21
     end
 
-    it { should == '[ 50.00%]' }
+    it { is_expected.to eq('[ 50.00%]') }
   end
 
 end

--- a/spec/progress_bar_spec.rb
+++ b/spec/progress_bar_spec.rb
@@ -4,7 +4,7 @@ describe 'ProgressBar bar output' do
   before do
     Timecop.freeze Time.utc(2010, 3, 10, 0, 0, 0)
     @progress_bar = ProgressBar.new(100)
-    @progress_bar.stub(:terminal_width) { 60 }
+    allow(@progress_bar).to receive(:terminal_width) { 60 }
     Timecop.freeze Time.utc(2010, 3, 10, 0, 0, 10) # 10 seconds later
   end
 
@@ -15,7 +15,7 @@ describe 'ProgressBar bar output' do
       @progress_bar.count = 0
     end
 
-    it { should == "[              ] [  0/100] [  0%] [00:10] [00:00] [  0.00/s]" }
+    it { is_expected.to eq("[              ] [  0/100] [  0%] [00:10] [00:00] [  0.00/s]") }
   end
 
   describe 'at count=50' do
@@ -23,7 +23,7 @@ describe 'ProgressBar bar output' do
       @progress_bar.count = 50
     end
 
-    it { should == "[#######       ] [ 50/100] [ 50%] [00:10] [00:10] [  5.00/s]" }
+    it { is_expected.to eq("[#######       ] [ 50/100] [ 50%] [00:10] [00:10] [  5.00/s]") }
   end
 
   describe 'at count=100' do
@@ -31,7 +31,7 @@ describe 'ProgressBar bar output' do
       @progress_bar.count = 100
     end
 
-    it { should == "[##############] [100/100] [100%] [00:10] [00:00] [ 10.00/s]" }
+    it { is_expected.to eq("[##############] [100/100] [100%] [00:10] [00:00] [ 10.00/s]") }
   end
 
   describe 'at count=105' do
@@ -39,7 +39,7 @@ describe 'ProgressBar bar output' do
       @progress_bar.count = 105
     end
 
-    it { should == "[##############] [100/100] [100%] [00:10] [00:00] [ 10.00/s]" }
+    it { is_expected.to eq("[##############] [100/100] [100%] [00:10] [00:00] [ 10.00/s]") }
   end
 
 end

--- a/spec/rate_spec.rb
+++ b/spec/rate_spec.rb
@@ -14,7 +14,7 @@ describe 'ProgressBar rate output' do
       @progress_bar.count = 0
     end
 
-    it { should == "[  0.00/s]" }
+    it { is_expected.to eq("[  0.00/s]") }
   end
 
   describe 'at count=50' do
@@ -22,7 +22,7 @@ describe 'ProgressBar rate output' do
       @progress_bar.count = 50
     end
 
-    it { should == "[  5.00/s]" }
+    it { is_expected.to eq("[  5.00/s]") }
   end
 
   describe 'at count=100' do
@@ -30,7 +30,7 @@ describe 'ProgressBar rate output' do
       @progress_bar.count = 100
     end
 
-    it { should == "[ 10.00/s]" }
+    it { is_expected.to eq("[ 10.00/s]") }
   end
 
   describe 'with a shorter max' do
@@ -41,7 +41,7 @@ describe 'ProgressBar rate output' do
       Timecop.freeze Time.utc(2010, 3, 10, 0, 0, 10) # 10 seconds later
     end
 
-    it { should == '[ 2.10/s]' }
+    it { is_expected.to eq('[ 2.10/s]') }
   end
 
   describe 'with a longer max' do
@@ -52,7 +52,7 @@ describe 'ProgressBar rate output' do
       Timecop.freeze Time.utc(2010, 3, 10, 0, 0, 10) # 10 seconds later
     end
 
-    it { should == '[   2.10/s]' }
+    it { is_expected.to eq('[   2.10/s]') }
   end
 
 end


### PR DESCRIPTION
This conversion is done by Transpec 2.3.7 with the following command:
    transpec

* 38 conversions
    from: == expected
      to: eq(expected)

* 30 conversions
    from: it { should ... }
      to: it { is_expected.to ... }

* 8 conversions
    from: obj.should
      to: expect(obj).to

* 2 conversions
    from: obj.stub(:message)
      to: allow(obj).to receive(:message)

* 1 conversion
    from: lambda { }.should
      to: expect { }.to

For more details: https://github.com/yujinakayama/transpec#supported-conversions