### PR TITLE
Minimal max value & #with_progress

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -85,15 +85,17 @@ rspec spec/*_spec.rb
 
 If you do a lot of progresses, you can shorten your way with this:
 
-    class Array
-      include ProgressBar::WithProgress
-    end
+```ruby
+class Array
+  include ProgressBar::WithProgress
+end
 
-    [1,2,3].each_with_progress{do_something}
+[1,2,3].each_with_progress{do_something}
 
-    # or any other Enumerable's methods:
+# or any other Enumerable's methods:
 
-    (1..1000).to_a.with_progress.select{|i| (i % 2).zero?}
+(1..1000).to_a.with_progress.select{|i| (i % 2).zero?}
+```
 
 You can include `ProgressBar::WithProgress` in any class, having methods
 `#count` and `#each`, like some DB datasets and so on.
@@ -101,8 +103,10 @@ You can include `ProgressBar::WithProgress` in any class, having methods
 If you are using progress_bar regularly on plain arrays, you may want to
 do:
 
-    require 'progress_bar/enumerable'
+```ruby
+require 'progress_bar/enumerable'
 
-    # it adds each_with_progress/with_progress to Array/Hash/Range
+# it adds each_with_progress/with_progress to Array/Hash/Range
 
-    (1..400).with_progress.select{|i| (i % 2).zero?}
+(1..400).with_progress.select{|i| (i % 2).zero?}
+```

--- a/README.mkd
+++ b/README.mkd
@@ -104,7 +104,7 @@ If you are using progress_bar regularly on plain arrays, you may want to
 do:
 
 ```ruby
-require 'progress_bar/enumerable'
+require 'progress_bar/core_ext/enumerable_with_progress'
 
 # it adds each_with_progress/with_progress to Array/Hash/Range
 

--- a/README.mkd
+++ b/README.mkd
@@ -81,6 +81,28 @@ gem install --development progress_bar
 rspec spec/*_spec.rb
 ```
 
+## Using ProgressBar on Enumerable-alikes.
 
+If you do a lot of progresses, you can shorten your way with this:
 
+    class Array
+      include ProgressBar::WithProgress
+    end
 
+    [1,2,3].each_with_progress{do_something}
+
+    # or any other Enumerable's methods:
+
+    (1..1000).to_a.with_progress.select{|i| (i % 2).zero?}
+
+You can include `ProgressBar::WithProgress` in any class, having methods
+`#count` and `#each`, like some DB datasets and so on.
+
+If you are using progress_bar regularly on plain arrays, you may want to
+do:
+
+    require 'progress_bar/enumerable'
+
+    # it adds each_with_progress/with_progress to Array/Hash/Range
+
+    (1..400).with_progress.select{|i| (i % 2).zero?}

--- a/examples/enumerable.rb
+++ b/examples/enumerable.rb
@@ -1,0 +1,4 @@
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib/progress_bar/enumerable'))
+
+p (20...34).with_progress.select{|i| sleep 0.1; (i % 2).zero?}

--- a/lib/progress_bar.rb
+++ b/lib/progress_bar.rb
@@ -188,3 +188,5 @@ class ProgressBar
   end
 
 end
+
+require_relative 'progress_bar/with_progress'

--- a/lib/progress_bar.rb
+++ b/lib/progress_bar.rb
@@ -15,7 +15,7 @@ class ProgressBar
     @meters     = [:bar, :counter, :percentage, :elapsed, :eta, :rate]
 
     @max        = args.shift if args.first.is_a? Numeric
-    raise ArgumentError, "Max must be a positive integer" unless @max > 0
+    raise ArgumentError, "Max must be a positive integer" unless @max >= 0
 
     @meters     = args unless args.empty?
 

--- a/lib/progress_bar/core_ext/enumerable_with_progress.rb
+++ b/lib/progress_bar/core_ext/enumerable_with_progress.rb
@@ -1,4 +1,4 @@
-require_relative '../progress_bar'
+require_relative '../../progress_bar'
 
 # FIXME: should there be a better method?..
 [Enumerable, Array, Hash, Range].each do |mod|

--- a/lib/progress_bar/enumerable.rb
+++ b/lib/progress_bar/enumerable.rb
@@ -1,0 +1,6 @@
+require_relative '../progress_bar'
+
+# FIXME: should there be a better method?..
+[Enumerable, Array, Hash, Range].each do |mod|
+  mod.send :include, ProgressBar::WithProgress
+end

--- a/lib/progress_bar/with_progress.rb
+++ b/lib/progress_bar/with_progress.rb
@@ -1,0 +1,18 @@
+class ProgressBar
+  module WithProgress
+    def each_with_progress(&block)
+      bar = ProgressBar.new(count)
+      if block
+        each{|obj| yield(obj).tap{bar.increment!}}
+      else
+        Enumerator.new{|yielder|
+          self.each do |obj|
+            (yielder << obj).tap{bar.increment!}
+          end
+        }
+      end
+    end
+
+    alias_method :with_progress, :each_with_progress
+  end
+end

--- a/spec/arguments_spec.rb
+++ b/spec/arguments_spec.rb
@@ -32,7 +32,7 @@ describe 'ProgressBar arguments' do
 
   it "should raise an error when initial max is nonsense" do
     lambda {
-      bar = ProgressBar.new(0)
+      bar = ProgressBar.new(-1)
     }.should raise_error(ProgressBar::ArgumentError)
   end
 

--- a/spec/with_progress_spec.rb
+++ b/spec/with_progress_spec.rb
@@ -1,0 +1,36 @@
+require File.expand_path(File.join(File.dirname(__FILE__), 'spec_helper'))
+
+describe ProgressBar::WithProgress do
+  context 'with block' do
+    let!(:bar){ProgressBar.new}
+    before{
+      Range.send(:include, ProgressBar::WithProgress)
+      allow(ProgressBar).to receive(:new){|max| bar.max = max; bar}
+    }
+    it 'should set max and increment on each iteration' do
+      (1..20).each_with_progress do |i|
+        break if i > 10
+      end
+      expect(bar.max).to eq 20
+      expect(bar.count).to eq 10
+    end
+  end
+
+  context 'without block' do
+    let!(:bar){ProgressBar.new}
+    before{
+      Range.send(:include, ProgressBar::WithProgress)
+      allow(ProgressBar).to receive(:new){|max| bar.max = max; bar}
+    }
+    it 'should give Enumerator' do
+      enum = (1..20).each_with_progress
+      expect(enum).to be_kind_of(Enumerator)
+      expect(bar.max).to eq 20
+      expect(bar.count).to eq 0
+
+      res = enum.map{|i| i + 1}
+      expect(res).to eq (2..21).to_a
+      expect(bar.count).to eq 20
+    end
+  end
+end


### PR DESCRIPTION
Two things.

**First (small)**: change minimal `ProgressBar#max` value from 1 to 0. 
Rationale: i constantly find myself to write code like:

```ruby
bar = ProgressBar.new(some_array.count)
some_array.each do 
  # something
  bar.increment!
end
```
...and it works every time except when array is empty. With this small change, it will work ok with empty arrays also.

**Second (huge).** I want to share the code I'm constantly finding myself to add to my projects: `ProgressBar::WithProgress` and its (optional) inclusion to `Enumerable`s. Just to write the things like:

```ruby
(1..1000).with_progress.select{...}
# or
MyModel.dataset.with_progress.each{....}
````