### PR TITLE
bar width differs while bar.increment!

### DIFF
--- a/lib/progress_bar.rb
+++ b/lib/progress_bar.rb
@@ -98,9 +98,11 @@ class ProgressBar
 
   def render_bar
     return '' if bar_width < 2
+    progress_width = (ratio * (bar_width - 2)).floor
+    remained_width = bar_width - 2 - progress_width
     "[" +
-      "#" * (ratio * (bar_width - 2)).ceil +
-      " " * ((1-ratio) * (bar_width - 2)).floor +
+      "#" * progress_width +
+      " " * remained_width +
     "]"
   end
 


### PR DESCRIPTION
in `ProgressBar#render_bar`

`(ratio * (bar_width - 2)).ceil + ((1-ratio) * (bar_width - 2)).floor` is not always equal to `bar_width - 2`

for example, with `@count = 5`, `@max = 17`, `ratio = 5.0/17.0`, `bar_width - 2 = 34`, the result of left is 33, not 34.