### PR TITLE
relax constraint on highline

### DIFF
--- a/progress_bar.gemspec
+++ b/progress_bar.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "progress_bar"
 
   s.add_dependency('options', '~> 2.3.0')
-  s.add_dependency('highline', '~> 1.6.1')
+  s.add_dependency('highline', '~> 1.6')
 
   s.add_development_dependency("rake")
   s.add_development_dependency("rspec")


### PR DESCRIPTION
The `highline` gem made some fixes that allow it work correctly with `jRuby` in the 1.7 series.
The dependency on `~> 1.6.1` prevents users from upgrading to the 1.7 series of highline.

All tests pass with highline 1.7.3 so I think we can safely relax this constraint.