### PR TITLE
Add license to gemspec

### DIFF
--- a/progress_bar.gemspec
+++ b/progress_bar.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.authors     = ["Paul Sadauskas"]
   s.email       = ["psadauskas@gmail.com"]
   s.homepage    = "http://github.com/paul/progress_bar"
+  s.license     = "WTFPL"
   s.summary     = "Simple Progress Bar for output to a terminal"
   s.description = "Give people feedback about long-running tasks without overloading them with information: Use a progress bar, like Curl or Wget!"
 


### PR DESCRIPTION
This PR adds license item to gemspec. This item is used as follows.

- Describing LICENSES on rubygems.org (https://rubygems.org/gems/progress_bar)
- List of licenses displayed by `bundle licenses` command

This will increase the opportunity for users to learn about license.
