### PR TITLE
core ext will include WithProgress on all Enumerables

### DIFF
--- a/lib/progress_bar/core_ext/enumerable_with_progress.rb
+++ b/lib/progress_bar/core_ext/enumerable_with_progress.rb
@@ -1,6 +1,7 @@
 require_relative '../../progress_bar'
 
-# FIXME: should there be a better method?..
-[Enumerable, Array, Hash, Range].each do |mod|
-  mod.send :include, ProgressBar::WithProgress
+ObjectSpace.each_object(Module) do |mod|
+  if mod <= Enumerable
+    mod.send :include, ProgressBar::WithProgress
+  end
 end


### PR DESCRIPTION
change progress_bar/core_ext/enumerable_with_progress to include in all Enumerables, not just a small fixed list.

the problem I was having was that an ActiveRecord relation did not have the #with_progress method because it was loaded before progress bar was. this is true for any class that included Enumerable before progress_bar/core_ext/enumerable_with_progress included WithProgress on Enumerable itself. here is a minimal example to reproduce:

```ruby
class Foo
  def each
    yield :foo
  end
  def count
    1
  end
  include Enumerable
end
require 'progress_bar/core_ext/enumerable_with_progress'
Foo.new.with_progress.to_a
```

results in `NoMethodError: undefined method `with_progress' for #<Foo:0x007f87d5a54290>`