### PR TITLE
allow highline to 2.x.x versation

### DIFF
--- a/progress_bar.gemspec
+++ b/progress_bar.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "progress_bar"
 
   s.add_dependency('options', '~> 2.3.0')
-  s.add_dependency('highline', '~> 1.6')
+  s.add_dependency('highline', '~> 2.0.0')
 
   s.add_development_dependency("rake")
   s.add_development_dependency("rspec")


### PR DESCRIPTION
Version 2.0.0 of highline gem has been released.
The dependency on 1.x.x prevents users from upgrading to the 2.x.x series of highline.