### PR TITLE
Fix slight issue with rubocop and Rails

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ require:
   - rubocop-rspec
 
 Rails:
-  Enabled: true
+  Enabled: false
 
 AllCops:
   DisplayCopNames: true


### PR DESCRIPTION
# What does this PR do?
- Makes the `rubocop.yml` not use Rails as this was causing Pronto to fail

I feel like Im littering PRs here but I didnt want to sneak this into one of my other PRs