### PR TITLE
Ability to pass meters to each_with_progress

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -110,3 +110,9 @@ require 'progress_bar/core_ext/enumerable_with_progress'
 
 (1..400).with_progress.select{|i| (i % 2).zero?}
 ```
+
+If you want to display only specific meters you can do it like so:
+
+```ruby
+(1..400).with_progress(:bar, :elapsed).select{|i| (i % 2).zero?}
+```

--- a/lib/progress_bar/with_progress.rb
+++ b/lib/progress_bar/with_progress.rb
@@ -1,7 +1,7 @@
 class ProgressBar
   module WithProgress
-    def each_with_progress(&block)
-      bar = ProgressBar.new(count)
+    def each_with_progress(*args, &block)
+      bar = ProgressBar.new(count, *args)
       if block
         each{|obj| yield(obj).tap{bar.increment!}}
       else


### PR DESCRIPTION
When you were using each_with_progress, you would always have all the meters being displayed and no ability to pick the one you want.

This change aims to give more control to users by adding the ability to pass the meters they want to see, the same way as when they create a new instance of ProgressBar.