### PR TITLE
Adds ProgressBar#puts

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -74,6 +74,8 @@ Style/HashSyntax:
     - lib/tasks/**/*.rake
 Style/NumericLiterals:
   Enabled: false
+Style/StringConcatenation:
+  Enabled: false
 Style/StringLiterals:
   Enabled: true
   EnforcedStyle: double_quotes

--- a/README.mkd
+++ b/README.mkd
@@ -20,14 +20,16 @@ lots of progress bar alternatives, and we thank you for using ProgressBar!
 
 ## The Easy Way
 
+```ruby
+require 'progress_bar'
 
-    require 'progress_bar'
-    bar = ProgressBar.new
+bar = ProgressBar.new
 
-    100.times do
-      sleep 0.1
-      bar.increment!
-    end
+100.times do
+  sleep 0.1
+  bar.increment!
+end
+```
 
 Produces output like:
 
@@ -42,15 +44,43 @@ it.*
 Usually, the defaults should be fine, the only thing you'll need to
 tweak is the max.
 
-    bar = ProgressBar.new(1000)
+```ruby
+bar = ProgressBar.new(1000)
+```
 
 ## Larger Steps
 
 If you want to process several things, and update less often, you can
 pass a number to `#increment!`
 
+```ruby
     bar.increment! 42
+```
 
+## Printing additional output
+
+Sometimes you want to print some additional messages in the output, but since the ProgressBar uses terminal control characters to replace the text on the same line on every update, the output looks funny:
+
+    [#######################################                           ] [ 59.00%] [00:06]
+    Hello!
+    [#########################################                         ] [ 60.00%] [00:05]
+
+To prevent this, you can use `ProgressBar#puts` so ProgressBar knows you want to print something, and it'll clear the bar before printing, then resume printing on the next line:
+
+```ruby
+100.times do |i|
+  sleep 0.1
+  bar.puts "Halfway there!" if i == 50
+  bar.increment!
+end
+```
+
+Produces output like:
+
+    Halfway there!
+    [##################################] [100/100] [100%] [00:10] [00:00] [  9.98/s]
+
+Try it out in `examples/printing_messages.rb` to see how it looks.
 
 ## Picking the meters
 
@@ -58,7 +88,9 @@ By default, ProgressBar will use all available meters (this will
 probably change). To select which meters you want, and in which order,
 pass them to the constructor:
 
-    bar = ProgressBar.new(100, :bar, :rate, :eta)
+```ruby
+bar = ProgressBar.new(100, :bar, :rate, :eta)
+```
 
 
 ### Available Meters

--- a/examples/printing_messages.rb
+++ b/examples/printing_messages.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "../lib/progress_bar"
+
+bar = ProgressBar.new
+
+100.times do |i|
+  sleep 0.1
+  bar.puts("Some long text\nthat contains newlines") if i == 10
+  bar.puts("Halfway there!") if i == 50
+  bar.puts("Almost done!") if i == 90
+  bar.increment!
+end
+
+__END__
+
+$ ruby examples/printing_messages.rb
+Some long text
+that contains newlines
+Halfway there!
+Almost done!
+[##################################] [100/100] [100%] [00:10] [00:00] [  9.98/s]

--- a/lib/progress_bar.rb
+++ b/lib/progress_bar.rb
@@ -36,9 +36,15 @@ class ProgressBar
     end
   end
 
-  def write
+  def puts(text)
     clear!
-    print to_s
+    $stderr.write(text)
+    $stderr.puts
+    write
+  end
+
+  def write
+    print "\r" + to_s
   end
 
   def remaining
@@ -87,7 +93,7 @@ class ProgressBar
   end
 
   def clear!
-    print "\r"
+    print "\r" + " " * terminal_width + "\r"
   end
 
   def render(meter)

--- a/spec/print_spec.rb
+++ b/spec/print_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "ProgressBar print output" do
+  let(:progress_bar) { ProgressBar.new(:counter) }
+
+  before do
+    allow(progress_bar).to receive(:terminal_width).and_return(10)
+  end
+
+  it "should replace the current bar with the text, and continue the bar on the next line" do
+    expect {
+      progress_bar.increment!
+      progress_bar.puts("Hello, world!")
+    }.to output("\r[  1/100]" \
+                "\r#{' ' * 10}" \
+                "\rHello, world!\n" \
+                "\r[  1/100]").to_stderr
+  end
+end


### PR DESCRIPTION
Adds support to print messages without interfering with the output of the bar.

See README and `examples/printing_messages.rb`.

```
Some long text
that contains newlines
Halfway there!
Almost done!
[##################################] [100/100] [100%] [00:10] [00:00] [  9.98/s]
```