### PR TITLE
Fixed use of unqualified Time class

### DIFF
--- a/lib/progress_bar.rb
+++ b/lib/progress_bar.rb
@@ -24,7 +24,7 @@ class ProgressBar
 
     @hl = HighLine.new
     @terminal_width = 80
-    @last_width_adjustment = Time.at(0)
+    @last_width_adjustment = ::Time.at(0)
   end
 
   def increment!(count = 1)


### PR DESCRIPTION
It seems if you have another progress bar gem installed[1], the also use
the ProgressBar namespace and declare a `Time` class within that
namespace. If I use the unqualified `Time` instead of `::Time`, then
that other one gets picked up and doesn't work.

Fixes #57

1: https://github.com/jfelchner/ruby-progressbar/blob/master/lib/ruby-progressbar/time.rb