### PR TITLE
Relax the `highline` dependency to allow version 3 and higher

### DIFF
--- a/Changelog.mkd
+++ b/Changelog.mkd
@@ -1,3 +1,7 @@
+# 1.3.4
+
+ * Relaxed highline gem requirement even further, to allow any 1.6+ version [#62](https://github.com/paul/progress_bar/pull/62)
+
 # 1.3.3
 
  * Fixed use of unqualified ::Time that was conflicting with another

--- a/lib/progress_bar/version.rb
+++ b/lib/progress_bar/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class ProgressBar
-  VERSION = "1.3.3"
+  VERSION = "1.3.4"
 end

--- a/progress_bar.gemspec
+++ b/progress_bar.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.4.0"
 
-  s.add_dependency("highline", [">= 1.6", "< 3"])
+  s.add_dependency("highline", ">= 1.6")
   s.add_dependency("options", "~> 2.3.0")
 
   s.add_development_dependency("rake")


### PR DESCRIPTION
To address #61

I looked at the [HighLine release notes](https://github.com/JEG2/highline/blob/master/Changelog.md#301--2024-01-20) for versions 3+, and I think it's all bug fixes and internal refactoring. Looks safe to me & tests pass locally, but please look carefully (I am no expert at ProgressBar or HighLine)