### PR TITLE
skip Refinements when including on existing Enumerable modules

### DIFF
--- a/lib/progress_bar/core_ext/enumerable_with_progress.rb
+++ b/lib/progress_bar/core_ext/enumerable_with_progress.rb
@@ -3,7 +3,7 @@
 require_relative "../../progress_bar"
 
 ObjectSpace.each_object(Module) do |mod|
-  if mod <= Enumerable
+  if !mod.is_a?(Refinement) && mod <= Enumerable
     mod.send :include, ProgressBar::WithProgress
   end
 end


### PR DESCRIPTION
Refinement#include removed as of Ruby 3.2