### PR TITLE
ProgressBar::WithProgress use #size when available

### DIFF
--- a/lib/progress_bar/with_progress.rb
+++ b/lib/progress_bar/with_progress.rb
@@ -3,7 +3,7 @@
 class ProgressBar
   module WithProgress
     def each_with_progress(*args, &block)
-      bar = ProgressBar.new(count, *args)
+      bar = ProgressBar.new(respond_to?(:size) && size || count, *args)
       if block
         each{ |obj| yield(obj).tap{ bar.increment! } }
       else


### PR DESCRIPTION
Since #count iterates the enumerable, it can be quite slow. #size is not always available but when it is, it can be much faster than #count.
For some large enumerables I work with, iterating the whole thing takes minutes, so doing it once for count and once for the actual iteration is terribly slow. These use an Enumerator with a block specifying size, and that is computed in relatively insignificant time, so using than when it is available is much better.